### PR TITLE
Adding bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "bind-polyfill",
+  
+  "authors": [
+    "Mozilla"
+  ],
+  "main": "index.js",
+  "license": "MIT",
+  "private": true,
+  "_resolution": {
+    "type": "branch",
+    "branch": "master",
+    "commit": "25200f3f8973a51f7201c2241991e6a9dcc45819"
+  }
+}


### PR DESCRIPTION
With the bower.json file added, grunt's bowerInstallComponents task can pull bind-polyfill into an app automatically.
